### PR TITLE
Migration warning

### DIFF
--- a/abstrackr/templates/accounts/dashboard.mako
+++ b/abstrackr/templates/accounts/dashboard.mako
@@ -23,11 +23,15 @@
             height: 120,
             width:500, 
             modal: true,
-            autoOpen: true,
+            autoOpen: false,
             show: "blind",
         });
         
+        $("#migration-warning").dialog( "open" );
+
     });
+
+
 
 </script>
 
@@ -35,7 +39,7 @@
 <div id="export" class="dialog"></div>
 
 <div id="migration-warning" class="ui-dialog">
-    <b>Important Notice:</b> Scheduled system updates will take place on <i>Saturday, February 4th from 11pm to midnight (Eastern Standard Time)</i>. The users may experience interruptions during this window.
+    <b>Important Notice:</b> Scheduled system updates will take place on <i>Saturday, February 4th from 11pm to midnight (Eastern Standard Time)</i>. Users may experience interruptions during this window.
 </div>
 
 <button type="button" onclick="introJs().start()">Quick Tour!</button>

--- a/abstrackr/templates/accounts/dashboard.mako
+++ b/abstrackr/templates/accounts/dashboard.mako
@@ -19,6 +19,13 @@
             show: "blind",
         });
         
+        $("#migration-warning").dialog({
+            height: 120,
+            width:500, 
+            modal: true,
+            autoOpen: true,
+            show: "blind",
+        });
         
     });
 
@@ -26,6 +33,10 @@
 
 
 <div id="export" class="dialog"></div>
+
+<div id="migration-warning" class="ui-dialog">
+    <b>Important Notice:</b> Scheduled system updates will take place on <i>Saturday, February 4th from 11pm to midnight (Eastern Standard Time)</i>. The users may experience interruptions during this window.
+</div>
 
 <button type="button" onclick="introJs().start()">Quick Tour!</button>
 	


### PR DESCRIPTION
I tested on safari and chrome and it seems to me that switching tabs do not trigger the popup, which makes sense because "ready" function should load once the page is loaded and not every time the tab becomes visible.